### PR TITLE
Fix: panic: runtime error: index out of range

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -23,9 +23,10 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"github.com/k1LoW/exec"
 	"strconv"
 	"strings"
+
+	"github.com/k1LoW/exec"
 
 	"github.com/labstack/gommon/color"
 	"github.com/spf13/cobra"
@@ -110,7 +111,7 @@ var launchCmd = &cobra.Command{
 		}
 		trackCommand = append(trackCommand, optSlackChannel...)
 		// slack-mention
-		if optSlackChannel[1] != "" {
+		if len(optSlackChannel) == 2 && optSlackChannel[1] != "" {
 			optSlackMention, err := optionSlackMention(slackMention, nonInteractive)
 			if err != nil {
 				_, _ = fmt.Fprintf(os.Stderr, "%s\n", err)


### PR DESCRIPTION
```
goroutine 1 [running]:
github.com/k1LoW/sheer-heart-attack/cmd.glob..func1(0x4822c60, 0x4847b50, 0x0, 0x0)
        /Users/k1low/src/github.com/k1LoW/sheer-heart-attack/cmd/launch.go:113 +0x184c
github.com/spf13/cobra.(*Command).execute(0x4822c60, 0x4847b50, 0x0, 0x0, 0x4822c60, 0x4847b50)
        /Users/k1low/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:766 +0x2ae
github.com/spf13/cobra.(*Command).ExecuteC(0x4822ec0, 0xc0000f9f68, 0x43adaee, 0x4822ec0)
        /Users/k1low/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:852 +0x2ec
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/k1low/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:800
github.com/k1LoW/sheer-heart-attack/cmd.Execute()
        /Users/k1low/src/github.com/k1LoW/sheer-heart-attack/cmd/root.go:52 +0x32
main.main()
        /Users/k1low/src/github.com/k1LoW/sheer-heart-attack/main.go:26 +0x20
```